### PR TITLE
"files" がないと、publish にビルドファイルが含まれない

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "access": "restricted",
     "registry": "https://npm.pkg.github.com"
   },
+  "files": [
+    "dist"
+  ],
   "license": "UNLICENSED",
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
おそらく、.gitignore を見てしまって dist フォルダが publish が含まれないようになっている。

`.npmignore` があればここを見るだろう